### PR TITLE
Use prettier for markdown formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+
+      - name: Check Prettier formatting
+        run: npx prettier --prose-wrap always --check "**/*.md"

--- a/ENGINEERING.md
+++ b/ENGINEERING.md
@@ -2,72 +2,132 @@
 
 ### Foreword & Context
 
-This repository shows a prototype concept of how `Python Wheels` could be made specific to any hardware - platform - device (internal or external) - silicone - etc.
+This repository shows a prototype concept of how `Python Wheels` could be made
+specific to any hardware - platform - device (internal or external) - silicone -
+etc.
 
-We would like to argue that Python today supports a very wide variety of platforms, unfortunately the existing following are not sufficient to cover today's needs:
+We would like to argue that Python today supports a very wide variety of
+platforms, unfortunately the existing following are not sufficient to cover
+today's needs:
+
 - Python ABI version
 - OS
-- CPU architecture 
+- CPU architecture
 - Build ID
 
 All of which summarized by the following regex:
+
 ```python
 r"^(?P<namever>(?P<name>[^\s-]+?)-(?P<ver>[^\s-]+?))(-(?P<build>\d[^\s-]*))?-(?P<pyver>[^\s-]+?)-(?P<abi>[^\s-]+?)-(?P<plat>\S+)\.whl$"
 ```
 
-We argue in this PEP, that multiple wheels with the same Python ABI / OS / CPU Arch can be built to support different platforms (in a large meaning): CPU-only vs GPU-enabled vs FPGA-enabled.
+We argue in this PEP, that multiple wheels with the same Python ABI / OS / CPU
+Arch can be built to support different platforms (in a large meaning): CPU-only
+vs GPU-enabled vs FPGA-enabled.
 
 ### Today, all solutions are suboptimal
 
-- Using dedidacated indexes per platform (one index for GPU wheels, one index for CPU wheels, etc.). All of which sharing usually the exact same name though having vastly different behavior and/or dependencies and/or features. And to add to the injury, if users don't read the documentation with attention, they are most likely to end up with a non-functioning install or very suboptimal (having a GPU build on a system which doesn't have a GPU - at best unnecessary downloads - at worst it won't work altogether). Obviously this approach breaks every core python assumptions: `pip freeze` & friends because a "wheel / package" with version is not unique.
+- Using dedidacated indexes per platform (one index for GPU wheels, one index
+  for CPU wheels, etc.). All of which sharing usually the exact same name though
+  having vastly different behavior and/or dependencies and/or features. And to
+  add to the injury, if users don't read the documentation with attention, they
+  are most likely to end up with a non-functioning install or very suboptimal
+  (having a GPU build on a system which doesn't have a GPU - at best unnecessary
+  downloads - at worst it won't work altogether). Obviously this approach breaks
+  every core python assumptions: `pip freeze` & friends because a "wheel /
+  package" with version is not unique.
 
-- Including all dependencies imaginable in one MEGA-Wheel (CPU, NVIDIA GPU, AMD GPU, Google TPU, FPGA, etc.) and detecting at runtime "what the platform supports" and activating the corresponding code-paths/dependencies. This usually makes heavy use of lazy imports and can rapidly lead to a very bloated download/install sequence due to the plaetora of unnecessary dependencies installed. This appraoch essentially trades "efficiency & network impact" for user friendliness (limited need to "read the documentation": just install and it works). This approach unfortunately also comes at a high cost "for the community" putting a high stress and load on WareHouse (PyPI.org) and we are already reaching the limit of what "this approach can do" (total repo size, maximum size per wheel, bandwidth generated, etc.).
+- Including all dependencies imaginable in one MEGA-Wheel (CPU, NVIDIA GPU, AMD
+  GPU, Google TPU, FPGA, etc.) and detecting at runtime "what the platform
+  supports" and activating the corresponding code-paths/dependencies. This
+  usually makes heavy use of lazy imports and can rapidly lead to a very bloated
+  download/install sequence due to the plaetora of unnecessary dependencies
+  installed. This appraoch essentially trades "efficiency & network impact" for
+  user friendliness (limited need to "read the documentation": just install and
+  it works). This approach unfortunately also comes at a high cost "for the
+  community" putting a high stress and load on WareHouse (PyPI.org) and we are
+  already reaching the limit of what "this approach can do" (total repo size,
+  maximum size per wheel, bandwidth generated, etc.).
 
-- One can also create package / metapackage (alias package - empty shells just redirecting properly) dedicated per "platform": `mypackage-gpu` or `mypackage-cpu`. This approach has some advantages, but still minor drawbacks:
+- One can also create package / metapackage (alias package - empty shells just
+  redirecting properly) dedicated per "platform": `mypackage-gpu` or
+  `mypackage-cpu`. This approach has some advantages, but still minor drawbacks:
   - Where do you stop: `mypackage-cpu-arm-v7` or `mypackage-cpu-arm-v7.1` ?
-  Obviously if you don't force yourself to "stay as generic as possible" you rapidly end up with a literal explosion of packages (imagine combining multiple "variables" in a combinatorial way).
-  - **MOST IMPORTANTLY:** this approach is total death blow to python dependency management. How can a package express a dependency of `mypackage` if there exist 15 of them. Extra environments maybe ? You better read the documentation VERY closely. The easiest/most reasonable is most certainly to on-purpose omit the explicit dependency `package -> mypackage` and - at runtime - if the import of `mypackage` fails, issue a well formatted error message sending the user to the documentation on what version of `mypackage` to install and how.
+    Obviously if you don't force yourself to "stay as generic as possible" you
+    rapidly end up with a literal explosion of packages (imagine combining
+    multiple "variables" in a combinatorial way).
+  - **MOST IMPORTANTLY:** this approach is total death blow to python dependency
+    management. How can a package express a dependency of `mypackage` if there
+    exist 15 of them. Extra environments maybe ? You better read the
+    documentation VERY closely. The easiest/most reasonable is most certainly to
+    on-purpose omit the explicit dependency `package -> mypackage` and - at
+    runtime - if the import of `mypackage` fails, issue a well formatted error
+    message sending the user to the documentation on what version of `mypackage`
+    to install and how.
 
 ### Wheel Variants: a mechanism to automatically detect "best package match" for the target platform.
 
-A `Wheel Variant` is defined as a "*flavored package*" specific to a certain number of attributes externally defined / detected and controlled.
+A `Wheel Variant` is defined as a "_flavored package_" specific to a certain
+number of attributes externally defined / detected and controlled.
 
-Let's imagine the creators of `TARS` (i.e. InterStellar) would want to create a `Wheel Variant` of `numpy`. Because there is absolutely zero doubt InterStellar AI is powered by Python, they consequently need to access `numpy` for trajectory calculations.
+Let's imagine the creators of `TARS` (i.e. InterStellar) would want to create a
+`Wheel Variant` of `numpy`. Because there is absolutely zero doubt InterStellar
+AI is powered by Python, they consequently need to access `numpy` for trajectory
+calculations.
 
 ### Provider Plugins - How do you detect what platform you're on and decide on the best match.
 
-Which leads us to the concept of `Provider Plugin`, we need a system to detect the user platform is `TARS` and consequently grab the appropriate `Python Wheel`. Most likely that system will be designed, released and maintained by the creator/manufacturer of `TARS`, but nothing prevents anyone to `fork the provider plugin` and alter the selection logic (license permitting).
+Which leads us to the concept of `Provider Plugin`, we need a system to detect
+the user platform is `TARS` and consequently grab the appropriate
+`Python Wheel`. Most likely that system will be designed, released and
+maintained by the creator/manufacturer of `TARS`, but nothing prevents anyone to
+`fork the provider plugin` and alter the selection logic (license permitting).
 
-Let's say that in our case we `fictional_hw`, to be `Provider Plugin`, it's able to "scan our machine and determine the best-matching `Variant` for this machine.
+Let's say that in our case we `fictional_hw`, to be `Provider Plugin`, it's able
+to "scan our machine and determine the best-matching `Variant` for this machine.
 
 ### Why a plugin you may ask ?
 
-*Oh my dear friend - I'm glad you ask!* 
+_Oh my dear friend - I'm glad you ask!_
 
-The core of the rational is that it's impossible to modify PIP (send PRs, etc.) every single time a new hardware / fix / etc. needs to get released. This would instantly turn into a massive burden for `PIP` maintainers and nobody wants that. At the same time,`Provider Plugin` may need to quickly iterate / adjust / modify their "selection logic" (bug fix, security fix, new product released/announced). And lastly because it's not part of `PIP` it becomes very easy for whoever needs it (that need should stay pretty rare though) to "fork and modify" the selection logic from a hardware vendor (at your own risk) and fit your needs. 
+The core of the rational is that it's impossible to modify PIP (send PRs, etc.)
+every single time a new hardware / fix / etc. needs to get released. This would
+instantly turn into a massive burden for `PIP` maintainers and nobody wants
+that. At the same time,`Provider Plugin` may need to quickly iterate / adjust /
+modify their "selection logic" (bug fix, security fix, new product
+released/announced). And lastly because it's not part of `PIP` it becomes very
+easy for whoever needs it (that need should stay pretty rare though) to "fork
+and modify" the selection logic from a hardware vendor (at your own risk) and
+fit your needs.
 
-So really, everybody wins in this context to have that "selection logic" external from `PIP`.
+So really, everybody wins in this context to have that "selection logic"
+external from `PIP`.
 
 ### I thought PIP does not have a public API - How do you implement a "Plugin" ?
 
-*Oh my dear friend - I'm glad you ask (again I know, you have good questions not my fault) !* 
+_Oh my dear friend - I'm glad you ask (again I know, you have good questions not
+my fault) !_
 
-Turns out there's a very elegant (I foresee some people ?preparing to? disagreeing already) way to allow a "plugin" interface without providing a public API to `PIP` in any sort of way.
+Turns out there's a very elegant (I foresee some people ?preparing to?
+disagreeing already) way to allow a "plugin" interface without providing a
+public API to `PIP` in any sort of way.
 
 Turns out a `packageA` can register an entrypoint for another `packageB`.
 
-This PEP will be supported by a library called `variantlib`, we propose that all plugins register an entrypoint as follows:
+This PEP will be supported by a library called `variantlib`, we propose that all
+plugins register an entrypoint as follows:
 
 ```toml
 [project.entry-points."variantlib.plugins"]
 my_plugin = "my_plugin.plugin:MyVariantPlugin"
 ```
 
-The only constraint is the following, `MyVariantPlugin` needs to follow the following "structure and signature"
+The only constraint is the following, `MyVariantPlugin` needs to follow the
+following "structure and signature"
 
-```python 
+```python
 # We will come back on `ProviderConfig` later.
-# For now - it's a "standardized way" to express arbitrary metadata 
+# For now - it's a "standardized way" to express arbitrary metadata
 # or attributes that are supported on this machine.
 from variantlib.config import ProviderConfig
 
@@ -80,63 +140,90 @@ class MyVariantPlugin:
 
     def run(self) -> ProviderConfig | None:
         """If the plugin is able to determine this platform/machine supports
-        custom "attributes/metadata" (defined and known by this plugin): 
+        custom "attributes/metadata" (defined and known by this plugin):
         => It returns a `ProviderConfig`, otherwise `None` (aka. ignore me).
         ...
 ```
 
 Nothing more - nothing less.
 
-And in case you need the rest of the story, on PIP side we can then apply the following:
+And in case you need the rest of the story, on PIP side we can then apply the
+following:
 
 ```python
 from importlib.metadata import entry_points
 plugins = entry_points().select(group="variantlib.plugins")
 
-for plugin in plugins:  
+for plugin in plugins:
     logger.info(f"Loading plugin: {plugin.name} - v{plugin.dist.version}")
 
     # Dynamically load the plugin class
-    plugin_class = plugin.load()  
+    plugin_class = plugin.load()
 
     # Instantiate the plugin
-    plugin_instance = plugin_class()  
+    plugin_instance = plugin_class()
 
     # Call the `run` method of the plugin
-    ... = plugin_instance.run()  
+    ... = plugin_instance.run()
 
     # do something with the result of the plugins
 ```
 
 **This approach has so many advantages:**
 
-- It's *standardized* and the proposed plugin standard is really minimalistic and easy to follow / modify as needed.
-- `PIP` still does not need to commit to any public API (no `from pip import XYZ` in sight) 
-- Does not require to overwrite files / folders of other packages or drop files within the tree of another package.
-- Last and not the least complete auto-discovery ! The user need to do nothing beyond `pip install myplugin` and the plugin gets auto-discovered when `PIP` needs it.
+- It's _standardized_ and the proposed plugin standard is really minimalistic
+  and easy to follow / modify as needed.
+- `PIP` still does not need to commit to any public API (no
+  `from pip import XYZ` in sight)
+- Does not require to overwrite files / folders of other packages or drop files
+  within the tree of another package.
+- Last and not the least complete auto-discovery ! The user need to do nothing
+  beyond `pip install myplugin` and the plugin gets auto-discovered when `PIP`
+  needs it.
 
 ## The Variant-Platform matching process
 
 Alright so now let's put everything back together. We have:
-- a package `mypackage` version `A.B.C` - packaged as a normal wheel and as a `Wheel Variant` for `TARS` platform.
 
-- a `Variant Provider` plugin `fictional_hw` which plugs into `variantlib` providing (hence the name) what kind of `Wheel Variant` are suitable for this machine and in what order of preference.
+- a package `mypackage` version `A.B.C` - packaged as a normal wheel and as a
+  `Wheel Variant` for `TARS` platform.
 
-- some new logic inside `PIP` which queries `variantlib.plugins` to determine if there is any existing `Wheel Variant` matching the user platform.
+- a `Variant Provider` plugin `fictional_hw` which plugs into `variantlib`
+  providing (hence the name) what kind of `Wheel Variant` are suitable for this
+  machine and in what order of preference.
+
+- some new logic inside `PIP` which queries `variantlib.plugins` to determine if
+  there is any existing `Wheel Variant` matching the user platform.
 
 We are almost there - let's clear a few points before full demo.
 
 ### How can we upload different "wheels" if they all represent the same "release" ?
 
-*Oh my dear friend - I'm glad you ask (again again I know, you have very good questions) !* 
+_Oh my dear friend - I'm glad you ask (again again I know, you have very good
+questions) !_
 
-For multiple reasons (explained below), we propose to slightly modify the regex above by adding a new capture group: `(~(?P<variant_hash>[0-9a-f]{8}))?` (essentially `~abcd1234` for those who don't speak fluently - not you I know that you know, other people :D).
+For multiple reasons (explained below), we propose to slightly modify the regex
+above by adding a new capture group: `(~(?P<variant_hash>[0-9a-f]{8}))?`
+(essentially `~abcd1234` for those who don't speak fluently - not you I know
+that you know, other people :D).
 
-This `hash` is constructed in a standardized by `variantlib` (which algorithm to use could be debated - for now `hashlib.shake_128()`)  and only use 8 characters which is plenty to guarantee unicity.
+This `hash` is constructed in a standardized by `variantlib` (which algorithm to
+use could be debated - for now `hashlib.shake_128()`) and only use 8 characters
+which is plenty to guarantee unicity.
 
-This `hash` is prefixed by `~` to make the filename extremely obvious to be a variant (aka. not generic but rather platform specific): `mypackage-0.0.1~9091cdc4-py3-none-any.whl`. The choice of `~` (instead of `#` for instance) was made because it's one of the very rare character with doesn't need escaping or convey a special meaning in a URL (like `#`, `@` or `?`). Ultimately it could be anything easy to recognize and that doesn't require complex escape or unintended consequence. `~` is unique and "fill all the boxes".
+This `hash` is prefixed by `~` to make the filename extremely obvious to be a
+variant (aka. not generic but rather platform specific):
+`mypackage-0.0.1~9091cdc4-py3-none-any.whl`. The choice of `~` (instead of `#`
+for instance) was made because it's one of the very rare character with doesn't
+need escaping or convey a special meaning in a URL (like `#`, `@` or `?`).
+Ultimately it could be anything easy to recognize and that doesn't require
+complex escape or unintended consequence. `~` is unique and "fill all the
+boxes".
 
-Modifying the "wheel validation" regex has one "hidden" major advantage: it makes any `Variant Wheel` an invalid filename for any version of PIP which does not support variants. Consequently guaranteeing, this PEP does break any old release of `PIP` by publishing `Python Wheels` in a previously unsupported.
+Modifying the "wheel validation" regex has one "hidden" major advantage: it
+makes any `Variant Wheel` an invalid filename for any version of PIP which does
+not support variants. Consequently guaranteeing, this PEP does break any old
+release of `PIP` by publishing `Python Wheels` in a previously unsupported.
 
 Consequently on disk - we have the following:
 
@@ -150,59 +237,111 @@ mypackage-0.0.1~4f8ae729-py3-none-any.whl
 mypackage-0.0.1~36266d4d-py3-none-any.whl
 ```
 
-If the user need to know what `mypackage-0.0.1~e684be6f-py3-none-any.whl` corresponds to, they can open the `METADATA` file which contains the relevant variant information (which has been hashed).
+If the user need to know what `mypackage-0.0.1~e684be6f-py3-none-any.whl`
+corresponds to, they can open the `METADATA` file which contains the relevant
+variant information (which has been hashed).
 
 ### From the plugin to the Variant Hash to the Install
 
-Let's pretend the user is doing `pip install fictional_hw` (the plugin) and then later `pip install package`, how does the whole process look like under the hood ?
+Let's pretend the user is doing `pip install fictional_hw` (the plugin) and then
+later `pip install package`, how does the whole process look like under the hood
+?
 
-1. `PIP` asks `variantlib` to collect all the `ProviderConfig` and generate a combinatorial product of possibilities which are "possible on this machine":
-   1. `variantlib` calls on each `installed plugin` and ask them to analyze the platform (a few example below)
+1. `PIP` asks `variantlib` to collect all the `ProviderConfig` and generate a
+   combinatorial product of possibilities which are "possible on this machine":
+   1. `variantlib` calls on each `installed plugin` and ask them to analyze the
+      platform (a few example below)
       - do you support AVX 512 ?
       - do you have the NVIDIA driver installed ? which version ?
       - which version of ARM is your CPU (e.g. ARMv7, ARMv8, etc.)
-      - what type of networking do you have (e.g. ethernet vs roc-e vs infiniband, etc.)
+      - what type of networking do you have (e.g. ethernet vs roc-e vs
+        infiniband, etc.)
 
-   2. Each Plugin generate a `ProviderConfig` and returns it. This object contains all the attribute the plugin was able to match this machine/platform with
+   2. Each Plugin generate a `ProviderConfig` and returns it. This object
+      contains all the attribute the plugin was able to match this
+      machine/platform with
 
-   3. `variantlib` creates a combinatorial product of all the attributes provided by the all the plugins, respecting the priority order (user-controllable).
+   3. `variantlib` creates a combinatorial product of all the attributes
+      provided by the all the plugins, respecting the priority order
+      (user-controllable).
 
-2. `variantlib` generates the `hash value` for each configuration compatible on this machine and `PIP` searches - in order - if any matching `Wheel Variant` is available on the indexes.
+2. `variantlib` generates the `hash value` for each configuration compatible on
+   this machine and `PIP` searches - in order - if any matching `Wheel Variant`
+   is available on the indexes.
 
-3. Finally, if a `Variant-match` was found => the best match (given the priority order) is installed, if none was found - the non-variant package is installed: `mypackage-0.0.1-py3-none-any.whl`
+3. Finally, if a `Variant-match` was found => the best match (given the priority
+   order) is installed, if none was found - the non-variant package is
+   installed: `mypackage-0.0.1-py3-none-any.whl`
 
-All that process happens very fast because it's essentially just a generation of hashes and a look up in a hashmap if a given hash value exists. It's near-invisible to the user.
+All that process happens very fast because it's essentially just a generation of
+hashes and a look up in a hashmap if a given hash value exists. It's
+near-invisible to the user.
 
------------------------
+---
 
 ## A few design details important for user experience
 
-It is crucial to understand that Wheel Variants are a totally optional mechanism that probably 99% of packages will never need. However, many of the very important projects for the Python Community may have a serious usecase for them. Namely those shipping with compiled binaries.
+It is crucial to understand that Wheel Variants are a totally optional mechanism
+that probably 99% of packages will never need. However, many of the very
+important projects for the Python Community may have a serious usecase for them.
+Namely those shipping with compiled binaries.
 
-This proposal aims to propose a framework and mechanism to specify arbitrary information and resolve them on the user-machine. We try to be as little specific and/or opiniated on what "information" may mean (hence we used fictional references). We believe this proposal can be used in ways we don't necessarily anticipate today and it's by design. We want to leave the freedom in the design to not specify what doesn't need to specified.
+This proposal aims to propose a framework and mechanism to specify arbitrary
+information and resolve them on the user-machine. We try to be as little
+specific and/or opiniated on what "information" may mean (hence we used
+fictional references). We believe this proposal can be used in ways we don't
+necessarily anticipate today and it's by design. We want to leave the freedom in
+the design to not specify what doesn't need to specified.
 
-Below are a few detail points of "User Experience" that we tried to consider in the demonstrator - they appear important to us and we wanted to be able to provide a full answer to allow you to project yourself into a `Variant-enabled` future.
+Below are a few detail points of "User Experience" that we tried to consider in
+the demonstrator - they appear important to us and we wanted to be able to
+provide a full answer to allow you to project yourself into a `Variant-enabled`
+future.
 
-1. The relative priority of `pluginA` vs `pluginB` should be either controllable using `pip.conf` or using a `pip install --flag` We obviously want to let the user decide what plugin should take the precedence if two plugins are installed simultaneously.
+1. The relative priority of `pluginA` vs `pluginB` should be either controllable
+   using `pip.conf` or using a `pip install --flag` We obviously want to let the
+   user decide what plugin should take the precedence if two plugins are
+   installed simultaneously.
 
-2. We might envision a command `pip organize_variant_provider` that will provide a new UI and modify the `pip.conf` for you in the background (e.g. chose the most important plugin, now chosen the second most important, etc.).
+2. We might envision a command `pip organize_variant_provider` that will provide
+   a new UI and modify the `pip.conf` for you in the background (e.g. chose the
+   most important plugin, now chosen the second most important, etc.).
 
-3. This mostly concerns supercomputers AFAIK - Some usecases share a unique `virtualenv` (in read-only) between thousands of workers. The node doing the install of the virtualenv does not necessarily have access to the "real production environment", consequently it's important to be able to force the resolution to variant `abcd1234` if the user asks for it `pip install --force-variant=abcd1234 mypackage`. It's niche but important.
+3. This mostly concerns supercomputers AFAIK - Some usecases share a unique
+   `virtualenv` (in read-only) between thousands of workers. The node doing the
+   install of the virtualenv does not necessarily have access to the "real
+   production environment", consequently it's important to be able to force the
+   resolution to variant `abcd1234` if the user asks for it
+   `pip install --force-variant=abcd1234 mypackage`. It's niche but important.
 
-4. A user may also want to disable the `variant` feature/behavior altogether: `pip install --no-variant mypackage`
+4. A user may also want to disable the `variant` feature/behavior altogether:
+   `pip install --no-variant mypackage`
 
-5. I believe for `lockfiles` (discussed in other places) we may want `variant infos` to be included (I honestly don't have opinion). 
+5. I believe for `lockfiles` (discussed in other places) we may want
+   `variant infos` to be included (I honestly don't have opinion).
 
-6. To the contrary, I would argue we don't want `variant infos` to be inside `pip freeze`. It is frequently used to generate `requirements.txt` files: `pip freeze > requirements.txt`, the whole point of `Wheel Variants` is to let `PIP` decide what `Wheel Variant` (if any) is most appropriate for a given machine. Forcing the variant hash into `pip freeze` (or the dependencies/optional-dependencies inside `pyproject.toml`), entirely defeats the purpose to have this "resolution" eagerly executed.
+6. To the contrary, I would argue we don't want `variant infos` to be inside
+   `pip freeze`. It is frequently used to generate `requirements.txt` files:
+   `pip freeze > requirements.txt`, the whole point of `Wheel Variants` is to
+   let `PIP` decide what `Wheel Variant` (if any) is most appropriate for a
+   given machine. Forcing the variant hash into `pip freeze` (or the
+   dependencies/optional-dependencies inside `pyproject.toml`), entirely defeats
+   the purpose to have this "resolution" eagerly executed.
 
-7. Each variant provider plugin may want to provide a "debug command" `myprovider debug --verbose` or so giving the details of how the platform is being analyzed and resolved. We don't believe that interface shall be standardized, it shall be up to the plugin authors to decide what information they believe useful to help the user understand why they don't get the variant they expect to get.
+7. Each variant provider plugin may want to provide a "debug command"
+   `myprovider debug --verbose` or so giving the details of how the platform is
+   being analyzed and resolved. We don't believe that interface shall be
+   standardized, it shall be up to the plugin authors to decide what information
+   they believe useful to help the user understand why they don't get the
+   variant they expect to get.
    - Maybe a different plugin has the priority
-   - Maybe the detection mechanism has a problem (e.g. some library is missing in the `LD_LIBRARY_PATH`)
-   - Maybe provide a link to a forum / discord / slack / stackoverflow / email / github to get support.
+   - Maybe the detection mechanism has a problem (e.g. some library is missing
+     in the `LD_LIBRARY_PATH`)
+   - Maybe provide a link to a forum / discord / slack / stackoverflow / email /
+     github to get support.
    - etc.
 
-
----------------
+---
 
 ### Demo - we designed a simplified `pip` copy to show the design & behavior without diving too deep into the details (yet).
 
@@ -211,7 +350,7 @@ pip install -i http://localhost:5000/simple/ myypackage
 [I 2025-01-28 02:08:34.091 pip.commands.install:57 v0.1.0] Received install request for: `myypackage` from index: http://localhost:5000/simple/.
 [I 2025-01-28 02:08:34.092 pip.repository:30 v0.1.0] Querying `http://localhost:5000/simple/myypackage/` for package `myypackage`
 [I 2025-01-28 02:08:34.096 pip.repository:38 v0.1.0] Successfully fetched package data from `http://localhost:5000/simple/myypackage/`
-[I 2025-01-28 02:08:34.097 pip.commands.install:70 v0.1.0] 
+[I 2025-01-28 02:08:34.097 pip.commands.install:70 v0.1.0]
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1-py3-none-any.whl`
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1~e684be6f-py3-none-any.whl`
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1~9091cdc4-py3-none-any.whl`
@@ -219,7 +358,7 @@ pip install -i http://localhost:5000/simple/ myypackage
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1~57768a46-py3-none-any.whl`
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1~4f8ae729-py3-none-any.whl`
 [I 2025-01-28 02:08:34.097 pip.commands.install:75 v0.1.0] Found: `myypackage-0.0.1~36266d4d-py3-none-any.whl`
-[I 2025-01-28 02:08:34.097 pip.commands.install:79 v0.1.0] 
+[I 2025-01-28 02:08:34.097 pip.commands.install:79 v0.1.0]
 [I 2025-01-28 02:08:34.097 pip.variant_hash:69 v0.1.0] Discovering plugins...
 [I 2025-01-28 02:08:34.108 pip.variant_hash:86 v0.1.0] Loading plugin: fictional_tech - v1.0.0
 [I 2025-01-28 02:08:34.110 pip.variant_hash:86 v0.1.0] Loading plugin: fictional_hw - v1.0.0
@@ -228,9 +367,17 @@ pip install -i http://localhost:5000/simple/ myypackage
 [I 2025-01-28 02:08:34.129 pip.commands.install:102 v0.1.0] Variant-Data: fictional_tech :: risk_exposure :: 25
 [I 2025-01-28 02:08:34.129 pip.commands.install:102 v0.1.0] Variant-Data: fictional_tech :: technology :: auto_chef
 [I 2025-01-28 02:08:34.129 pip.commands.install:103 v0.1.0] ################################################################################
-[I 2025-01-28 02:08:34.129 pip.commands.install:127 v0.1.0] 
+[I 2025-01-28 02:08:34.129 pip.commands.install:127 v0.1.0]
 [I 2025-01-28 02:08:34.129 pip.commands.install:128 v0.1.0] Installing: myypackage-0.0.1~9091cdc4-py3-none-any.whl ...
 [========================================] 100%
-[I 2025-01-28 02:08:36.259 pip.commands.install:130 v0.1.0] 
+[I 2025-01-28 02:08:36.259 pip.commands.install:130 v0.1.0]
 [I 2025-01-28 02:08:36.259 pip.commands.install:132 v0.1.0] The package: `myypackage` (Version: `0.0.1`) was installed with success ...
+```
+
+## Contributing
+
+We use prettier to format markdown file. You can run it with:
+
+```shell
+npx prettier --prose-wrap always --write "**/*.md"
 ```

--- a/README.md
+++ b/README.md
@@ -22,23 +22,22 @@
   </a>
 </p>
 
-
 # Wheel Variant Tutorials
 
 ## Installation Tutorials
 
 **The following tutorials are available:**
 
-| Project   | Link                              | Linux x86_64 | Linux AARCH64 | Windows AMD64 | MacOS x86_64 | MacOS ARM64 |
-| :-------: | :-------------------------------: | :----------: | :-----------: | :-----------: | :----------: | :---------: |
-| Numpy     | [Link](docs/tutorials/Numpy.md)   |  ✅          |  ✅            | ✅            |  ✅          |  ✅          |
-| PyTorch   | [Link](docs/tutorials/PyTorch.md) |  ✅          |  ❌            | ✅            |  ❌          |  ❌          |
-| XGBoost   | [Link](docs/tutorials/XGBoost.md) |  ✅          |  ❌            | ✅            |  ❌          |  ❌          |
+| Project |               Link                | Linux x86_64 | Linux AARCH64 | Windows AMD64 | MacOS x86_64 | MacOS ARM64 |
+| :-----: | :-------------------------------: | :----------: | :-----------: | :-----------: | :----------: | :---------: |
+|  Numpy  |  [Link](docs/tutorials/Numpy.md)  |      ✅      |      ✅       |      ✅       |      ✅      |     ✅      |
+| PyTorch | [Link](docs/tutorials/PyTorch.md) |      ✅      |      ❌       |      ✅       |      ❌      |     ❌      |
+| XGBoost | [Link](docs/tutorials/XGBoost.md) |      ✅      |      ❌       |      ✅       |      ❌      |     ❌      |
 
 ## Package Building Tutorials
 
-| Project      | Link                                   |
+|   Project    |                  Link                  |
 | :----------: | :------------------------------------: |
 | Meson-Python | [Link](docs/tutorials/meson-python.md) |
-| Flit         |       |
-| CLI API      |       |
+|     Flit     |                                        |
+|   CLI API    |                                        |

--- a/docs/design/base_definitions.md
+++ b/docs/design/base_definitions.md
@@ -2,33 +2,30 @@
 
 ## Purpose
 
-This document aims to streamline the terminology used within the code,
-project documentation and discussions.
-
+This document aims to streamline the terminology used within the code, project
+documentation and discussions.
 
 ## Variants
 
-*Variant wheels* refer to wheels that share the same distribution name,
-version, build number and compatible tags, but have different contents
-and are distinguished by unique variant properties. For example, variant
-wheels may provide package versions built for different accelerators,
-CPU optimizations, etc.
+_Variant wheels_ refer to wheels that share the same distribution name, version,
+build number and compatible tags, but have different contents and are
+distinguished by unique variant properties. For example, variant wheels may
+provide package versions built for different accelerators, CPU optimizations,
+etc.
 
-Variant wheels function as an extension of the wheel format.
-A particular distribution may feature a regular (non-variant) wheel
-in addition to variant wheels, in which case it serves both
-as a lowest-precedence variant, and as a fallback for installers that
-do not support variants.
-
+Variant wheels function as an extension of the wheel format. A particular
+distribution may feature a regular (non-variant) wheel in addition to variant
+wheels, in which case it serves both as a lowest-precedence variant, and as a
+fallback for installers that do not support variants.
 
 ## Variant descriptions, properties, features
 
-*Variant description* is the whole set of metadata describing
-a particular variant.  It consists of one or more variant properties,
-and it has a corresponding *variant hash*.
+_Variant description_ is the whole set of metadata describing a particular
+variant. It consists of one or more variant properties, and it has a
+corresponding _variant hash_.
 
-*Variant property* is a 3-tuple describing a single specific feature
-that the variant was built for.  It has a form of:
+_Variant property_ is a 3-tuple describing a single specific feature that the
+variant was built for. It has a form of:
 
     namespace :: feature-name :: feature-value
 
@@ -36,43 +33,37 @@ For example:
 
     CUDA :: runtime :: 12.8
 
-*Namespace* identifies the plugin providing particular features,
-and must be globally unique. For example, the `CUDA` namespace
-is claimed by a CUDA plugin, and all feature provided by that plugin
-will use that namespace.
+_Namespace_ identifies the plugin providing particular features, and must be
+globally unique. For example, the `CUDA` namespace is claimed by a CUDA plugin,
+and all feature provided by that plugin will use that namespace.
 
-*Feature name* names the particular feature within the plugin, and must
-be unique within the namespace. For example, the `runtime` feature name
-within the `CUDA` namespace identifies the CUDA runtime version.
+_Feature name_ names the particular feature within the plugin, and must be
+unique within the namespace. For example, the `runtime` feature name within the
+`CUDA` namespace identifies the CUDA runtime version.
 
-*Feature* is a term referring to all possible values corresponding
-to a particular `(namespace, feature-name)` pair: `CUDA :: runtime`
-in the example.
+_Feature_ is a term referring to all possible values corresponding to a
+particular `(namespace, feature-name)` pair: `CUDA :: runtime` in the example.
 
-*Feature value* is the selected feature value for the given variant.
-It must be unique within the feature. In the example, `CUDA :: runtime`
-feature has a value of `12.8`.
-
+_Feature value_ is the selected feature value for the given variant. It must be
+unique within the feature. In the example, `CUDA :: runtime` feature has a value
+of `12.8`.
 
 ## Plugins
 
-*Plugins* provide the underlying architecture for building
-and installing variant wheels. Every plugin claims a single namespace.
-The plugin defines all valid feature names and values within that
-namespace, as well as their meanings.
+_Plugins_ provide the underlying architecture for building and installing
+variant wheels. Every plugin claims a single namespace. The plugin defines all
+valid feature names and values within that namespace, as well as their meanings.
 
 A plugin implements a specific API that provides routines to:
 
 - query all valid feature names and values
 
-- query feature names and versions that are compatible with
-  the environment in question, as well as their relative precedence
-  (possibly none)
+- query feature names and versions that are compatible with the environment in
+  question, as well as their relative precedence (possibly none)
 
-For example, the CUDA plugin both defines all valid values
-for `CUDA :: runtime`, i.e. all known CUDA runtime versions, but also
-indicates which values are valid for a given environment.  That is,
-it detects whether CUDA runtime is installed, and either returns
-a preference-sorted list of compatible CUDA runtime versions,
-or indicates that the runtime is not installed and no CUDA variants
-can be installed.
+For example, the CUDA plugin both defines all valid values for
+`CUDA :: runtime`, i.e. all known CUDA runtime versions, but also indicates
+which values are valid for a given environment. That is, it detects whether CUDA
+runtime is installed, and either returns a preference-sorted list of compatible
+CUDA runtime versions, or indicates that the runtime is not installed and no
+CUDA variants can be installed.

--- a/docs/design/metadata.md
+++ b/docs/design/metadata.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-This document describes the metadata format used for variant wheels.
-The format is used in three locations, with slight variations:
+This document describes the metadata format used for variant wheels. The format
+is used in three locations, with slight variations:
 
 1. in the source repository, as a `pyproject.toml` file,
 
@@ -11,32 +11,29 @@ The format is used in three locations, with slight variations:
 
 3. on the wheel index, as a `*-variants.json` file.
 
-All three variants share a common structure, with some of its element
-shared across all of them, and some being specific to a single variant,
-as described further in the document. This structure is then serialized
-into TOML or JSON appropriately.
+All three variants share a common structure, with some of its element shared
+across all of them, and some being specific to a single variant, as described
+further in the document. This structure is then serialized into TOML or JSON
+appropriately.
 
-These variations fit into the common wheel building pipeline where
-a source tree is used to build one or more wheels, and the wheels
-are afterwards published on an index. The `pyproject.toml` file
-provides the metadata needed to build the wheels, as well as the shared
-metadata needed to install them. This metadata is then amended with
-information on the specific variant build, and copied into the wheel.
-When wheels are uploaded into the index, the metadata from all of them
-is read and merged into a single JSON file that can be used
-by the client to efficiently evaluate the available variants without
-having to fetch metadata from every wheel separately.
-
+These variations fit into the common wheel building pipeline where a source tree
+is used to build one or more wheels, and the wheels are afterwards published on
+an index. The `pyproject.toml` file provides the metadata needed to build the
+wheels, as well as the shared metadata needed to install them. This metadata is
+then amended with information on the specific variant build, and copied into the
+wheel. When wheels are uploaded into the index, the metadata from all of them is
+read and merged into a single JSON file that can be used by the client to
+efficiently evaluate the available variants without having to fetch metadata
+from every wheel separately.
 
 ## The metadata structure
 
 ### The metadata tree
 
-The metadata is a dictionary rooted at a specific point, specified
-for each file separately. The top-level keys of this dictionary
-are strings corresponding to specific metadata blocks, and their values
-are further dictionaries representing this blocks. The complete
-structure can be visualized using the following tree:
+The metadata is a dictionary rooted at a specific point, specified for each file
+separately. The top-level keys of this dictionary are strings corresponding to
+specific metadata blocks, and their values are further dictionaries representing
+this blocks. The complete structure can be visualized using the following tree:
 
 ```
 (root)
@@ -71,42 +68,39 @@ structure can be visualized using the following tree:
 |      +- plugin-api    : str | None
 ```
 
-The wheel metadata includes the provider metadata dictionary that
-specifies which variant providers (plugins) are available, under what
-conditions they are used, how to install them and how to use them.
+The wheel metadata includes the provider metadata dictionary that specifies
+which variant providers (plugins) are available, under what conditions they are
+used, how to install them and how to use them.
 
-It resides under the `providers` key. It is a dictionary using namespace
-names as keys, with values being dictionaries describing the provider
-for a given namespace. This sub-dictionary has up to three keys:
+It resides under the `providers` key. It is a dictionary using namespace names
+as keys, with values being dictionaries describing the provider for a given
+namespace. This sub-dictionary has up to three keys:
 
-1. `requires: list[str]` -- that specifies one or more [dependency specifiers](
-   https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
+1. `requires: list[str]` -- that specifies one or more
+   [dependency specifiers](https://packaging.python.org/en/latest/specifications/dependency-specifiers/)
    specifying how the provider should be installed. This key is required.
 
-2. `enable-if: str | None` -- that optionally specifies an [environment marker](
-   https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers)
-   specifying when the plugin should be used. If it specified, the plugin
-   will not be installed and loaded if the environment does not match
-   the specified markers. If it not specified, the plugin is enabled
-   unconditionally.
+2. `enable-if: str | None` -- that optionally specifies an
+   [environment marker](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers)
+   specifying when the plugin should be used. If it specified, the plugin will
+   not be installed and loaded if the environment does not match the specified
+   markers. If it not specified, the plugin is enabled unconditionally.
 
-3. `plugin-api: str` -- that specifies how to load plugins. If specified,
-   it follows the same format as object references
-   in the [entry points specification](
-   https://packaging.python.org/en/latest/specifications/entry-points/).
+3. `plugin-api: str` -- that specifies how to load plugins. If specified, it
+   follows the same format as object references in the
+   [entry points specification](https://packaging.python.org/en/latest/specifications/entry-points/).
    It can be one of:
-
    - `importable.module:ClassName`
    - `importable.module:attribute`
    - `importable.module`
 
-   If not specified, it will be inferred from the first package name
-   found in `requires`, with any dashes replaced with underscores.
-   For example, if the dependency is `foo-bar[extra] >= 1.2.3`,
-   its corresponding `plugin-api` will be inferred as `foo_bar`.
+   If not specified, it will be inferred from the first package name found in
+   `requires`, with any dashes replaced with underscores. For example, if the
+   dependency is `foo-bar[extra] >= 1.2.3`, its corresponding `plugin-api` will
+   be inferred as `foo_bar`.
 
-   If a callable is specified, the provider will be instantiated
-   by the equivalent of:
+   If a callable is specified, the provider will be instantiated by the
+   equivalent of:
 
    ```python
    import importable.module
@@ -114,15 +108,14 @@ for a given namespace. This sub-dictionary has up to three keys:
    plugin_instance = importable.module.ClassName()
    ```
 
-   If a non-callable object (e.g. a module or a global object)
-   is specified, it will be used directly, similarly to:
+   If a non-callable object (e.g. a module or a global object) is specified, it
+   will be used directly, similarly to:
 
    ```python
    import importable.module
 
    plugin_instance = importable.module.attribute
    ```
-
 
 ### Default priorities
 
@@ -136,36 +129,33 @@ for a given namespace. This sub-dictionary has up to three keys:
 |         +- <feature>  : list[str]
 ```
 
-The default priority block is used to establish the default preferences
-between variants. It must specify the order for all namespaces used
-by the package. It may also override the priorities of individual
-features and property values provided by the plugins. The priorities
-specified here can in turn be overridden by the user.
+The default priority block is used to establish the default preferences between
+variants. It must specify the order for all namespaces used by the package. It
+may also override the priorities of individual features and property values
+provided by the plugins. The priorities specified here can in turn be overridden
+by the user.
 
-The block resides under the `default-priorities` key. It is a dictionary
-with up to three keys:
+The block resides under the `default-priorities` key. It is a dictionary with up
+to three keys:
 
-1. `namespace: list[str]` -- that lists all namespaces used
-   by the package from the most preferred to the least preferred.
+1. `namespace: list[str]` -- that lists all namespaces used by the package from
+   the most preferred to the least preferred.
 
-2. `feature` -- that can be used to override preferred feature order
-   of individual providers. It is a dictionary whose keys are namespaces,
-   and values are lists of feature names. The features are listed from
-   the most preferred to the least preferred. Not all features provided
-   by the plugin need be listed. The remaining features will be given
-   lower priority than these listed, while preserving their relative
-   order provided by the plugin.
+2. `feature` -- that can be used to override preferred feature order of
+   individual providers. It is a dictionary whose keys are namespaces, and
+   values are lists of feature names. The features are listed from the most
+   preferred to the least preferred. Not all features provided by the plugin
+   need be listed. The remaining features will be given lower priority than
+   these listed, while preserving their relative order provided by the plugin.
 
-3. `property` -- that can be used to override preferred property value
-   order of individual providers. It consists of two nested dictionaries,
-   with the key of the top dictionary specifying the namespace name,
-   and the key of the subsequent dictionary specifying the feature name.
-   The values are property values, ordered from the most preferred
-   to the least preferred. Conversely, not all property values provided
-   by the plugin need be listed. The remaining properties will be given
-   lower priority than these listed, while preserving their relative
-   order provided by the plugin.
-
+3. `property` -- that can be used to override preferred property value order of
+   individual providers. It consists of two nested dictionaries, with the key of
+   the top dictionary specifying the namespace name, and the key of the
+   subsequent dictionary specifying the feature name. The values are property
+   values, ordered from the most preferred to the least preferred. Conversely,
+   not all property values provided by the plugin need be listed. The remaining
+   properties will be given lower priority than these listed, while preserving
+   their relative order provided by the plugin.
 
 ### Variants
 
@@ -176,28 +166,26 @@ with up to three keys:
           +- <feature>  : str
 ```
 
-The variants block is present only in wheel metadata, and in wheel
-index `*-variants.json` file. In both cases it is obligatory.
-In the former file, it specifies the variant that the wheel was built
-for. In the latter, it lists all variants available for the package
-version.
+The variants block is present only in wheel metadata, and in wheel index
+`*-variants.json` file. In both cases it is obligatory. In the former file, it
+specifies the variant that the wheel was built for. In the latter, it lists all
+variants available for the package version.
 
-It resides under the `variants` key. It is a dictionary using variant
-hashes as keys, with values listing the properties for a given variant
-in a form of a nested dictionary. The keys of the top dictionary
-specify namespaces names, the keys of the subsequent dictionary feature
-names and their values are the corresponding property values.
-
+It resides under the `variants` key. It is a dictionary using variant hashes as
+keys, with values listing the properties for a given variant in a form of a
+nested dictionary. The keys of the top dictionary specify namespaces names, the
+keys of the subsequent dictionary feature names and their values are the
+corresponding property values.
 
 ## Specific file formats
 
 ### `pyproject.toml`
 
-The `pyproject.toml` file is the standard project configuration file
-as defined in [pyproject.toml specification](
-https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-toml-spec).
-The variant metadata is rooted at the top-level `variant` table.
-This format does not include the `variants` dictionary.
+The `pyproject.toml` file is the standard project configuration file as defined
+in
+[pyproject.toml specification](https://packaging.python.org/en/latest/specifications/pyproject-toml/#pyproject-toml-spec).
+The variant metadata is rooted at the top-level `variant` table. This format
+does not include the `variants` dictionary.
 
 Example `pyproject.toml` tables, with explanatory comments:
 
@@ -231,86 +219,71 @@ plugin-api = "provider_variant_x86_64.plugin:X8664Plugin"
 
 ### `*.dist-info/variant.json`
 
-The `variant.json` file is placed inside variant wheels,
-in the `*.dist-info` directory containing the wheel metadata. It is
-serialized into JSON, with variant metadata dictionary being the top
-object. In addition to the shared metadata copied from `pyproject.toml`,
-it contains a `variants` object that must list exactly one variant --
-the variant provided by the wheel.
+The `variant.json` file is placed inside variant wheels, in the `*.dist-info`
+directory containing the wheel metadata. It is serialized into JSON, with
+variant metadata dictionary being the top object. In addition to the shared
+metadata copied from `pyproject.toml`, it contains a `variants` object that must
+list exactly one variant -- the variant provided by the wheel.
 
 The `default-priorities` and `providers` for all wheels of the same package
 version on the same index must be the same and be equal to value in
 `*-variants.json`.
 
-The `variant.json` file corresponding to the wheel built from
-the example `pyproject.toml` file for x86-64-v3 would look like:
+The `variant.json` file corresponding to the wheel built from the example
+`pyproject.toml` file for x86-64-v3 would look like:
 
 ```json
 {
-    "default-priorities": {
-        "feature": {
-            "aarch64": [
-                "version"
-            ],
-            "x86_64": [
-                "level"
-            ]
-        },
-        "namespace": [
-            "x86_64",
-            "aarch64"
-        ],
-        "property": {
-            "x86_64": {
-                "level": [
-                    "v3",
-                    "v2",
-                    "v1"
-                ]
-            }
-        }
+  "default-priorities": {
+    "feature": {
+      "aarch64": ["version"],
+      "x86_64": ["level"]
     },
-    "providers": {
-        "aarch64": {
-            "enable-if": "platform_machine == 'aarch64' or 'arm' in platform_machine",
-            "plugin-api": "provider_variant_aarch64.plugin:AArch64Plugin",
-            "requires": [
-                "provider-variant-aarch64 >=0.0.1,<1; python_version >= '3.9'",
-                "legacy-provider-variant-aarch64 >=0.0.1,<1; python_version < '3.9'"
-            ]
-        },
-        "x86_64": {
-            "enable-if": "platform_machine == 'x86_64' or platform_machine == 'AMD64'",
-            "plugin-api": "provider_variant_x86_64.plugin:X8664Plugin",
-            "requires": [
-                "provider-variant-x86-64 >=0.0.1,<1"
-            ]
-        }
-    },
-    "variants": {
-        "fa7c1393": {
-            "x86_64": {
-                "level": "v3"
-            }
-        }
+    "namespace": ["x86_64", "aarch64"],
+    "property": {
+      "x86_64": {
+        "level": ["v3", "v2", "v1"]
+      }
     }
+  },
+  "providers": {
+    "aarch64": {
+      "enable-if": "platform_machine == 'aarch64' or 'arm' in platform_machine",
+      "plugin-api": "provider_variant_aarch64.plugin:AArch64Plugin",
+      "requires": [
+        "provider-variant-aarch64 >=0.0.1,<1; python_version >= '3.9'",
+        "legacy-provider-variant-aarch64 >=0.0.1,<1; python_version < '3.9'"
+      ]
+    },
+    "x86_64": {
+      "enable-if": "platform_machine == 'x86_64' or platform_machine == 'AMD64'",
+      "plugin-api": "provider_variant_x86_64.plugin:X8664Plugin",
+      "requires": ["provider-variant-x86-64 >=0.0.1,<1"]
+    }
+  },
+  "variants": {
+    "fa7c1393": {
+      "x86_64": {
+        "level": "v3"
+      }
+    }
+  }
 }
 ```
 
 ### `*-variants.json`
 
-For every package version that includes at least one variant wheel,
-there must exist a corresponding `{name}-{version}-variants.json`
-file, where the package name and version are normalized according
-to the same rules as wheel files, as found in the [Binary Distribution
-Format specification](
-https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode).
-The link to this file must be present on all index pages where
-the variant wheels are linked, to facilitate discovery.
+For every package version that includes at least one variant wheel, there must
+exist a corresponding `{name}-{version}-variants.json` file, where the package
+name and version are normalized according to the same rules as wheel files, as
+found in the
+[Binary Distribution Format specification](https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode).
+The link to this file must be present on all index pages where the variant
+wheels are linked, to facilitate discovery.
 
-This file uses the same structure as `variant.json`, except that
-the `variants` object is permitted to list multiple variants, and should
-list all variants available for the package version in question.
+This file uses the same structure as `variant.json`, except that the `variants`
+object is permitted to list multiple variants, and should list all variants
+available for the package version in question.
 
 The file can be created from existing variant wheels using the following
 command:
@@ -321,63 +294,49 @@ variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-
 variantlib.commands.generate_index_json - INFO - Processing wheel: `numpy-2.2.5-cp313-cp313-linux_x86_64-fa7c1393.whl` with variant hash: `fa7c1393`
 ```
 
-The `foo-1.2.3-variants.json` corresponding to the package with two
-wheel variants, one of them listed in the previous example, would look
-like:
+The `foo-1.2.3-variants.json` corresponding to the package with two wheel
+variants, one of them listed in the previous example, would look like:
 
 ```json
 {
-    "default-priorities": {
-        "feature": {
-            "aarch64": [
-                "version"
-            ],
-            "x86_64": [
-                "level"
-            ]
-        },
-        "namespace": [
-            "x86_64",
-            "aarch64"
-        ],
-        "property": {
-            "x86_64": {
-                "level": [
-                    "v3",
-                    "v2",
-                    "v1"
-                ]
-            }
-        }
+  "default-priorities": {
+    "feature": {
+      "aarch64": ["version"],
+      "x86_64": ["level"]
     },
-    "providers": {
-        "aarch64": {
-            "enable-if": "platform_machine == 'aarch64' or 'arm' in platform_machine",
-            "plugin-api": "provider_variant_aarch64.plugin:AArch64Plugin",
-            "requires": [
-                "provider-variant-aarch64 >=0.0.1,<1; python_version >= '3.9'",
-                "legacy-provider-variant-aarch64 >=0.0.1,<1; python_version < '3.9'"
-            ]
-        },
-        "x86_64": {
-            "enable-if": "platform_machine == 'x86_64' or platform_machine == 'AMD64'",
-            "plugin-api": "provider_variant_x86_64.plugin:X8664Plugin",
-            "requires": [
-                "provider-variant-x86-64 >=0.0.1,<1"
-            ]
-        }
-    },
-    "variants": {
-        "40aba78e": {
-            "x86_64": {
-                "level": "v2"
-            }
-        },
-        "fa7c1393": {
-            "x86_64": {
-                "level": "v3"
-            }
-        }
+    "namespace": ["x86_64", "aarch64"],
+    "property": {
+      "x86_64": {
+        "level": ["v3", "v2", "v1"]
+      }
     }
+  },
+  "providers": {
+    "aarch64": {
+      "enable-if": "platform_machine == 'aarch64' or 'arm' in platform_machine",
+      "plugin-api": "provider_variant_aarch64.plugin:AArch64Plugin",
+      "requires": [
+        "provider-variant-aarch64 >=0.0.1,<1; python_version >= '3.9'",
+        "legacy-provider-variant-aarch64 >=0.0.1,<1; python_version < '3.9'"
+      ]
+    },
+    "x86_64": {
+      "enable-if": "platform_machine == 'x86_64' or platform_machine == 'AMD64'",
+      "plugin-api": "provider_variant_x86_64.plugin:X8664Plugin",
+      "requires": ["provider-variant-x86-64 >=0.0.1,<1"]
+    }
+  },
+  "variants": {
+    "40aba78e": {
+      "x86_64": {
+        "level": "v2"
+      }
+    },
+    "fa7c1393": {
+      "x86_64": {
+        "level": "v3"
+      }
+    }
+  }
 }
 ```

--- a/docs/design/plugin_api.md
+++ b/docs/design/plugin_api.md
@@ -2,49 +2,45 @@
 
 ## Purpose
 
-This document describes the API used by variant provider plugins.
-The plugins are a central point of the variant specification, defining
-the valid metadata, and providing routines necessary to install
-and build variants.
+This document describes the API used by variant provider plugins. The plugins
+are a central point of the variant specification, defining the valid metadata,
+and providing routines necessary to install and build variants.
 
-This document provides the API described both in text and using
-Python [Protocols]( https://typing.python.org/en/latest/spec/protocol.html)
-for convenience.
-
+This document provides the API described both in text and using Python
+[Protocols](https://typing.python.org/en/latest/spec/protocol.html) for
+convenience.
 
 ## Basic design
 
-Every provider plugin operates within a single namespace. The namespace
-is used as key for all plugin-related operations. All the properties
-defined by the plugin are in the plugin's namespace, and the plugin
-defines all the valid feature names and values within that namespace.
+Every provider plugin operates within a single namespace. The namespace is used
+as key for all plugin-related operations. All the properties defined by the
+plugin are in the plugin's namespace, and the plugin defines all the valid
+feature names and values within that namespace.
 
-Within a single package, only one plugin can be used for a given
-namespace. Attempting to load a second plugin sharing the same namespace
-must cause a fatal error. However, it is possible for multiple plugins
-using the namespace to exist, which implies that they become mutually
-exclusive. For example, this could happen if a plugin becomes
-unmaintained and needs to be forked into a new package.
+Within a single package, only one plugin can be used for a given namespace.
+Attempting to load a second plugin sharing the same namespace must cause a fatal
+error. However, it is possible for multiple plugins using the namespace to
+exist, which implies that they become mutually exclusive. For example, this
+could happen if a plugin becomes unmaintained and needs to be forked into a new
+package.
 
 Plugins are expected to be automatically installed when installing
-variant-enabled packages, in order to facilitate variant
-selection. Therefore, it is necessary that the packages providing
-plugins are installable with the same indices enabled that are used
-to install the package in question. In particular, packages published
-to PyPI must not rely on plugins that need to be installed from other
-indices.
+variant-enabled packages, in order to facilitate variant selection. Therefore,
+it is necessary that the packages providing plugins are installable with the
+same indices enabled that are used to install the package in question. In
+particular, packages published to PyPI must not rely on plugins that need to be
+installed from other indices.
 
-Plugins are implemented using a Python class. Their API can be
-accessed using two methods:
+Plugins are implemented using a Python class. Their API can be accessed using
+two methods:
 
 1. An explicit object reference, as the "plugin API" metadata.
 
-2. An installed entry point in the `variant_plugins` group. The name
-   of the entry point is insignificant, and the value provides
-   the object reference.
+2. An installed entry point in the `variant_plugins` group. The name of the
+   entry point is insignificant, and the value provides the object reference.
 
-Both formats use the object reference notation from the [entry point
-specification](https://packaging.python.org/en/latest/specifications/entry-points/).
+Both formats use the object reference notation from the
+[entry point specification](https://packaging.python.org/en/latest/specifications/entry-points/).
 That is, they are in the form of:
 
 ```
@@ -59,24 +55,23 @@ import importable.module
 plugin_instance = importable.module.ClassName()
 ```
 
-The explicit "plugin API" key is the primary method of using the plugin.
-It is part of the variant metadata, and it is therefore used while
-building and installing wheels.
+The explicit "plugin API" key is the primary method of using the plugin. It is
+part of the variant metadata, and it is therefore used while building and
+installing wheels.
 
 The entry point method is provided to increase the convenience of using
-variant-related tools. It is therefore normally used with plugins that
-are installed to user's main system. It can be used e.g. to detect
-and print all supported variant properties, to help user configure
-variant preferences or provide defaults to `pyproject.toml`.
+variant-related tools. It is therefore normally used with plugins that are
+installed to user's main system. It can be used e.g. to detect and print all
+supported variant properties, to help user configure variant preferences or
+provide defaults to `pyproject.toml`.
 
 ## Helper classes
 
 ### Variant feature config
 
-The variant feature config class is used to define a single variant
-feature, along with a list of possible values. Depending on the context,
-the order of values may be significant. It is defined using
-the following protocol:
+The variant feature config class is used to define a single variant feature,
+along with a list of possible values. Depending on the context, the order of
+values may be significant. It is defined using the following protocol:
 
 ```python
 from abc import abstractmethod
@@ -103,11 +98,11 @@ class VariantFeatureConfigType(Protocol):
 
 A "variant feature config" must provide two properties or attributes:
 
-- ``name`` specifying the feature name, as a string
+- `name` specifying the feature name, as a string
 
-- ``values`` specifying feature values, as a list of strings.
-  In contexts where the order is significant, the values must be
-  orderred from the most preferred to the least preferred.
+- `values` specifying feature values, as a list of strings. In contexts where
+  the order is significant, the values must be orderred from the most preferred
+  to the least preferred.
 
 All features are interpreted as being in the plugin's namespace.
 
@@ -123,11 +118,10 @@ class VariantFeatureConfig:
     values: list[str]
 ```
 
-
 ### Variant property
 
-The variant property type is used to represent a single variant property
-with a specific value. It is defined using the following protocol:
+The variant property type is used to represent a single variant property with a
+specific value. It is defined using the following protocol:
 
 ```python
 from abc import abstractmethod
@@ -218,7 +212,6 @@ class PluginType(Protocol):
         return {}
 ```
 
-
 ### Properties
 
 The plugin class must define a single property or attribute:
@@ -231,7 +224,6 @@ Example implementation:
 class MyPlugin:
     namespace = "example"
 ```
-
 
 ### `get_all_configs`
 
@@ -246,10 +238,10 @@ Prototype:
         ...
 ```
 
-This method is used to determine all the valid features within
-the provider's namespace. It must return a list of "variant feature
-configs", where every config defines a single feature along with all
-its possible values. The order of the returned values is insignificant.
+This method is used to determine all the valid features within the provider's
+namespace. It must return a list of "variant feature configs", where every
+config defines a single feature along with all its possible values. The order of
+the returned values is insignificant.
 
 Example implementation:
 
@@ -268,7 +260,6 @@ Example implementation:
         ]
 ```
 
-
 ### `get_supported_configs`
 
 Purpose: get features and their values supported on this system
@@ -282,11 +273,10 @@ Prototype:
         ...
 ```
 
-This method is used to determine which features are supported on this
-system. It must return a list of "variant feature configs", where every
-config defines a single feature along with all the supported values.
-The values should be ordered from the most preferred value to the least
-preferred.
+This method is used to determine which features are supported on this system. It
+must return a list of "variant feature configs", where every config defines a
+single feature along with all the supported values. The values should be ordered
+from the most preferred value to the least preferred.
 
 Example implementation:
 
@@ -304,7 +294,6 @@ Example implementation:
         ]
 ```
 
-
 ### `get_build_setup`
 
 Purpose: get build variables for the built variant
@@ -320,20 +309,19 @@ Prototype:
         ...
 ```
 
-This method is used to obtain "build variables" that are used
-by the build backend to configure the build of a specific variant.
-It is passed a list of variant properties, filtered to include only
-these matching the namespace used by the plugin. It must return
-a dictionary that maps build variable names into a list of string
-values. If multiple plugins include the same variable, their values
-are concatenated, in an undefined order.
+This method is used to obtain "build variables" that are used by the build
+backend to configure the build of a specific variant. It is passed a list of
+variant properties, filtered to include only these matching the namespace used
+by the plugin. It must return a dictionary that maps build variable names into a
+list of string values. If multiple plugins include the same variable, their
+values are concatenated, in an undefined order.
 
-The exact list of build variables and the meaning of their values
-is out of the scope for this document. Build backends should ignore
-the values they do not recognize or support.
+The exact list of build variables and the meaning of their values is out of the
+scope for this document. Build backends should ignore the values they do not
+recognize or support.
 
-The build setup implementation is likely to change, see [discussion
-on build setup](https://github.com/wheelnext/pep_xxx_wheel_variants/issues/23).
+The build setup implementation is likely to change, see
+[discussion on build setup](https://github.com/wheelnext/pep_xxx_wheel_variants/issues/23).
 
 Example implementation:
 
@@ -354,13 +342,12 @@ Example implementation:
         return {"cflags": cflags}
 ```
 
-
 ### Future extensions
 
-The future versions of this specification, as well as third-party
-extensions may introduce additional properties and methods on the plugin
-instances. The implementations should ignore additional attributes.
+The future versions of this specification, as well as third-party extensions may
+introduce additional properties and methods on the plugin instances. The
+implementations should ignore additional attributes.
 
-For best compatibility, it is recommended that all private attributes
-are prefixed with a underscore (`_`) character to avoid incidental
-conflicts with future extensions.
+For best compatibility, it is recommended that all private attributes are
+prefixed with a underscore (`_`) character to avoid incidental conflicts with
+future extensions.

--- a/docs/tutorials/Numpy.md
+++ b/docs/tutorials/Numpy.md
@@ -1,18 +1,20 @@
 # Wheel Variants - Numpy Tutorial
 
-This tutorial contains a simple demo of the `Wheel-Variant` implementation for `Numpy`.
+This tutorial contains a simple demo of the `Wheel-Variant` implementation for
+`Numpy`.
 
 > [!CAUTION]  
 > This Wheel Variant Demo currently contains **very experimental code**.<br>
-> This should be considered as a feature-preview and in no-way used in production.
+> This should be considered as a feature-preview and in no-way used in
+> production.
 
 | Linux x86_64 | Linux AARCH64 | Windows AMD64 | MacOS x86_64 | MacOS ARM64 |
 | :----------: | :-----------: | :-----------: | :----------: | :---------: |
-|  ✅          |  ✅            | ✅            |  ✅          |  ✅          |
+|      ✅      |      ✅       |      ✅       |      ✅      |     ✅      |
 
 ## Where to report issues / ask questions ?
 
-Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new 
+Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new
 
 ## A. Let's validate that an "old installer" is non-affected by any of these changes
 
@@ -32,7 +34,8 @@ Writing to /path/to/venv/pip.conf
 
 ### 2. Test Install a Variant-Enabled package with "normal `pip`"
 
-By doing this - It **should** install the normal package (aka. non variant), proving the backward compatibility of the design.
+By doing this - It **should** install the normal package (aka. non variant),
+proving the backward compatibility of the design.
 
 ```bash
 $ python3 -m pip install --dry-run numpy
@@ -46,15 +49,15 @@ Would install numpy-2.2.5
 
 ### What happened ?
 
-As you can expect - PIP picked up the default `numpy` build - same as published on PyPI.
-Built as a normal Python Wheel (aka. `non variant`)
+As you can expect - PIP picked up the default `numpy` build - same as published
+on PyPI. Built as a normal Python Wheel (aka. `non variant`)
 
 ## B. Let's install a variant-enabled Python package manager
 
 ### 1. Let's install variant-enabled PIP
 
-> [!CAUTION]
-> This command will overwrite your environment's `pip`. Make sure you are in the virtualenv.
+> [!CAUTION] This command will overwrite your environment's `pip`. Make sure you
+> are in the virtualenv.
 
 ```bash
 # Install the PEP XXX - Wheel Variants Meta Package, that will give you the modified libraries:
@@ -112,9 +115,11 @@ Would install numpy-2.2.5-cfdbe307
 
 #### What happened ?
 
-PIP is aware `numpy` is variant-enabled thanks to the presence of [`numpy-2.2.5-variants.json`](https://variants-index.wheelnext.dev/numpy/numpy-2.2.5-variants.json)
+PIP is aware `numpy` is variant-enabled thanks to the presence of
+[`numpy-2.2.5-variants.json`](https://variants-index.wheelnext.dev/numpy/numpy-2.2.5-variants.json)
 
-The file contains the instructions on how to install the variant plugins and parse the variants properties
+The file contains the instructions on how to install the variant plugins and
+parse the variants properties
 
 ```json
 {
@@ -144,15 +149,17 @@ The file contains the instructions on how to install the variant plugins and par
 }
 ```
 
-In this case both the `x86_64` and `aarch64` plugins shall be installed by default (see `default-priorities` key).
-With their relative "priority" not changing anything given that they are mutually exclusive.
+In this case both the `x86_64` and `aarch64` plugins shall be installed by
+default (see `default-priorities` key). With their relative "priority" not
+changing anything given that they are mutually exclusive.
 
-This platform contains an `x86_64` CPU - `pip` installs the right plugin and is able to detect which `x86_64` version this system supports.
-The following variants were available: https://variants-index.wheelnext.dev/numpy/
+This platform contains an `x86_64` CPU - `pip` installs the right plugin and is
+able to detect which `x86_64` version this system supports. The following
+variants were available: https://variants-index.wheelnext.dev/numpy/
 
-> [!IMPORTANT] 
-> In our case - this machine has the most advanced/recent `x86_64` version available so all `x86_64` variants are compatibles.
-> If you have a CPU with a `x86_64` version < 4 you will see some of the variant(s) rejected.
+> [!IMPORTANT] In our case - this machine has the most advanced/recent `x86_64`
+> version available so all `x86_64` variants are compatibles. If you have a CPU
+> with a `x86_64` version < 4 you will see some of the variant(s) rejected.
 
 Consequently, the installed variant corresponds to:
 

--- a/docs/tutorials/PyTorch.md
+++ b/docs/tutorials/PyTorch.md
@@ -1,18 +1,20 @@
 # Wheel Variants - PyTorch Tutorial
 
-This tutorial contains a simple demo of the `Wheel-Variant` implementation for `pytorch`.
+This tutorial contains a simple demo of the `Wheel-Variant` implementation for
+`pytorch`.
 
 > [!CAUTION]  
 > This Wheel Variant Demo currently contains **very experimental code**.<br>
-> This should be considered as a feature-preview and in no-way used in production.
+> This should be considered as a feature-preview and in no-way used in
+> production.
 
 | Linux x86_64 | Linux AARCH64 | Windows AMD64 | MacOS x86_64 | MacOS ARM64 |
 | :----------: | :-----------: | :-----------: | :----------: | :---------: |
-|  ✅          |  ❌            | ✅            |  ❌          |  ❌          |
+|      ✅      |      ❌       |      ✅       |      ❌      |     ❌      |
 
 ## Where to report issues / ask questions ?
 
-Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new 
+Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new
 
 ## A. Let's validate that an "old installer" is non-affected by any of these changes
 
@@ -32,7 +34,8 @@ Writing to /path/to/venv/pip.conf
 
 ### 2. Test Install a Variant-Enabled package with "normal `pip`"
 
-By doing this - It **should** install the normal package (aka. non variant), proving the backward compatibility of the design.
+By doing this - It **should** install the normal package (aka. non variant),
+proving the backward compatibility of the design.
 
 ```bash
 $ python3 -m pip install --dry-run torch
@@ -46,15 +49,15 @@ Would install torch-2.7.0
 
 ### What happened ?
 
-As you can expect - PIP picked up the default `torch` build - same as published on PyPI.
-Built as a normal Python Wheel (aka. `non variant`)
+As you can expect - PIP picked up the default `torch` build - same as published
+on PyPI. Built as a normal Python Wheel (aka. `non variant`)
 
 ## B. Let's install a variant-enabled Python package manager
 
 ### 1. Let's install variant-enabled PIP
 
-> [!CAUTION]
-> This command will overwrite your environment's `pip`. Make sure you are in the virtualenv.
+> [!CAUTION] This command will overwrite your environment's `pip`. Make sure you
+> are in the virtualenv.
 
 ```bash
 # Install the PEP XXX - Wheel Variants Meta Package, that will give you the modified libraries:
@@ -113,9 +116,11 @@ Would install torch-2.7.0-d5784ad6
 
 #### What happened ?
 
-PIP is aware `torch` is variant-enabled thanks to the presence of [`torch-2.7.0-variants.json`](https://variants-index.wheelnext.dev/torch/torch-2.7.0-variants.json)
+PIP is aware `torch` is variant-enabled thanks to the presence of
+[`torch-2.7.0-variants.json`](https://variants-index.wheelnext.dev/torch/torch-2.7.0-variants.json)
 
-The file contains the instructions on how to install the NVIDIA variant plugin and parse the variants properties
+The file contains the instructions on how to install the NVIDIA variant plugin
+and parse the variants properties
 
 ```json
 {
@@ -138,13 +143,16 @@ The file contains the instructions on how to install the NVIDIA variant plugin a
 }
 ```
 
-In this case both the `nvidia` plugin shall be installed by default (see `default-priorities` key).
+In this case both the `nvidia` plugin shall be installed by default (see
+`default-priorities` key).
 
-This platform contains an NVIDIA GPU and CUDA 12.8 - `pip` installs the right plugin and is able to detect which `NVIDIA CUDA` variants this system supports.
-The following variants were available: https://variants-index.wheelnext.dev/torch/
+This platform contains an NVIDIA GPU and CUDA 12.8 - `pip` installs the right
+plugin and is able to detect which `NVIDIA CUDA` variants this system supports.
+The following variants were available:
+https://variants-index.wheelnext.dev/torch/
 
-> [!IMPORTANT] 
-> In our case - this machine has the most recent `NVIDIA CUDA` version available so all variants under the CUDA 12 major are compatible.<br>
+> [!IMPORTANT] In our case - this machine has the most recent `NVIDIA CUDA`
+> version available so all variants under the CUDA 12 major are compatible.<br>
 > If you have an older CUDA version, you will see some variants rejected.
 
 Consequently, the installed variant corresponds to:
@@ -157,12 +165,15 @@ Variant-property: nvidia :: cuda :: 12.8
 
 ### What's next ?
 
-We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` environment variable and see how it changes the output.
+We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` environment
+variable and see how it changes the output.
+
 - Valid Values: `[CUDA 11] >=11.8` and `[CUDA 12] >=12.6`
-- Any other values (different major than 11/12 or major.minor not supported): installation of the `null-variant` (CPU only)
+- Any other values (different major than 11/12 or major.minor not supported):
+  installation of the `null-variant` (CPU only)
 
 ```bash
 export NV_PROVIDER_FORCE_DRIVER_VERSION="11.8"
-pip install --dry-run torch 
+pip install --dry-run torch
 ...
 ```

--- a/docs/tutorials/XGBoost.md
+++ b/docs/tutorials/XGBoost.md
@@ -1,18 +1,20 @@
 # Wheel Variants - XGBoost Tutorial
 
-This tutorial contains a simple demo of the `Wheel-Variant` implementation for `XGBoost`.
+This tutorial contains a simple demo of the `Wheel-Variant` implementation for
+`XGBoost`.
 
 > [!CAUTION]  
 > This Wheel Variant Demo currently contains **very experimental code**.<br>
-> This should be considered as a feature-preview and in no-way used in production.
+> This should be considered as a feature-preview and in no-way used in
+> production.
 
 | Linux x86_64 | Linux AARCH64 | Windows AMD64 | MacOS x86_64 | MacOS ARM64 |
 | :----------: | :-----------: | :-----------: | :----------: | :---------: |
-|  ✅          |  ❌            | ✅            |  ❌          |  ❌         |
+|      ✅      |      ❌       |      ✅       |      ❌      |     ❌      |
 
 ## Where to report issues / ask questions ?
 
-Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new 
+Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new
 
 ## A. Let's validate that an "old installer" is non-affected by any of these changes
 
@@ -32,7 +34,8 @@ Writing to /path/to/venv/pip.conf
 
 ### 2. Test Install a Variant-Enabled package with "normal `pip`"
 
-By doing this - It **should** install the normal package (aka. non variant), proving the backward compatibility of the design.
+By doing this - It **should** install the normal package (aka. non variant),
+proving the backward compatibility of the design.
 
 ```bash
 $ python3 -m pip install --dry-run xgboost
@@ -46,15 +49,15 @@ Would install xgboost-3.1.0
 
 ### What happened ?
 
-As you can expect - PIP picked up the default `xgboost` build - same as published on PyPI.
-Built as a normal Python Wheel (aka. `non variant`)
+As you can expect - PIP picked up the default `xgboost` build - same as
+published on PyPI. Built as a normal Python Wheel (aka. `non variant`)
 
 ## B. Let's install a variant-enabled Python package manager
 
 ### 1. Let's install variant-enabled PIP
 
-> [!CAUTION]
-> This command will overwrite your environment's `pip`. Make sure you are in the virtualenv.
+> [!CAUTION] This command will overwrite your environment's `pip`. Make sure you
+> are in the virtualenv.
 
 ```bash
 # Install the PEP XXX - Wheel Variants Meta Package, that will give you the modified libraries:
@@ -112,9 +115,11 @@ Would install xgboost-3.1.0-3f631cc2
 
 #### What happened ?
 
-PIP is aware `xgboost` is variant-enabled thanks to the presence of [`xgboost-3.1.0-variants.json`](https://variants-index.wheelnext.dev/xgboost/xgboost-3.1.0-variants.json)
+PIP is aware `xgboost` is variant-enabled thanks to the presence of
+[`xgboost-3.1.0-variants.json`](https://variants-index.wheelnext.dev/xgboost/xgboost-3.1.0-variants.json)
 
-The file contains the instructions on how to install the NVIDIA variant plugin and parse the variants properties
+The file contains the instructions on how to install the NVIDIA variant plugin
+and parse the variants properties
 
 ```json
 {
@@ -137,13 +142,16 @@ The file contains the instructions on how to install the NVIDIA variant plugin a
 }
 ```
 
-In this case both the `nvidia` plugin shall be installed by default (see `default-priorities` key).
+In this case both the `nvidia` plugin shall be installed by default (see
+`default-priorities` key).
 
-This platform contains an NVIDIA GPU and CUDA 12.8 - `pip` installs the right plugin and is able to detect which `NVIDIA CUDA` variants this system supports.
-The following variants were available: https://variants-index.wheelnext.dev/xgboost/
+This platform contains an NVIDIA GPU and CUDA 12.8 - `pip` installs the right
+plugin and is able to detect which `NVIDIA CUDA` variants this system supports.
+The following variants were available:
+https://variants-index.wheelnext.dev/xgboost/
 
-> [!IMPORTANT] 
-> In our case - this machine has the most recent `NVIDIA CUDA` version available so all variants under the CUDA 12 major are compatible.<br>
+> [!IMPORTANT] In our case - this machine has the most recent `NVIDIA CUDA`
+> version available so all variants under the CUDA 12 major are compatible.<br>
 > If you have an older CUDA version, you will see some variants rejected.
 
 Consequently, the installed variant corresponds to:
@@ -156,9 +164,12 @@ Variant-property: nvidia :: cuda :: 12
 
 ### What's next ?
 
-We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` environment variable and see how it changes the output.
+We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` environment
+variable and see how it changes the output.
+
 - Valid Values: `[CUDA 11] >=11.8` and `[CUDA 12] >=12.6`
-- Any other values (different major than 11/12 or major.minor not supported): installation of the `null-variant` (CPU only)
+- Any other values (different major than 11/12 or major.minor not supported):
+  installation of the `null-variant` (CPU only)
 
 ```bash
 export NV_PROVIDER_FORCE_DRIVER_VERSION="11.8"
@@ -166,29 +177,18 @@ python3 -m pip install --dry-run xgboost
 ...
 ```
 
-
-
-
-
-
-
-
-
-
-
-
-
 # Wheel Variants - XGBoost Tutorial
 
-This tutorial contains a simple demo of the `Wheel-Variant` implementation for `XGBoost`.
+This tutorial contains a simple demo of the `Wheel-Variant` implementation for
+`XGBoost`.
 
 > [!CAUTION]  
-> The Wheel Variant Demo only supports Windows & Linux on `X86_64` / `AMD64` CPU.<br>
-> We did not built any variant-artifact for MacOS or ARM CPUs.
+> The Wheel Variant Demo only supports Windows & Linux on `X86_64` / `AMD64`
+> CPU.<br> We did not built any variant-artifact for MacOS or ARM CPUs.
 
 ## Where to report issues / ask questions ?
 
-Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new 
+Please go to: https://github.com/wheelnext/pep_xxx_wheel_variants/issues/new
 
 ## A. Let's validate that an "old installer" is non-affected by any of these changes
 
@@ -208,7 +208,8 @@ Writing to /path/to/venv/pip.conf
 
 ### 2. Test Install a Variant-Enabled package with "normal `pip`"
 
-By doing this - It **should** install the normal package (aka. non variant), proving the backward compatibility of the design.
+By doing this - It **should** install the normal package (aka. non variant),
+proving the backward compatibility of the design.
 
 ```bash
 $ python3 -m pip install --dry-run xgboost
@@ -222,15 +223,16 @@ Would install numpy-2.2.5 scipy-1.15.2 xgboost-3.1.0
 
 ### What happened ?
 
-As you can expect - PIP picked up the default XGBoost build (same as published under `xgboost-cpu` on PyPI).
-Built as a normal Python Wheel (aka. `non variant`)
+As you can expect - PIP picked up the default XGBoost build (same as published
+under `xgboost-cpu` on PyPI). Built as a normal Python Wheel (aka.
+`non variant`)
 
 ## B. Let's install a variant-enabled Python package manager
 
 ### 1. Let's install variant-enabled PIP
 
-> [!CAUTION]
-> This command will overwrite your environment's `pip`. Make sure you are in the virtualenv.
+> [!CAUTION] This command will overwrite your environment's `pip`. Make sure you
+> are in the virtualenv.
 
 ```bash
 # Install the PEP XXX - Wheel Variants Meta Package, that will give you the modified libraries:
@@ -284,14 +286,17 @@ Would install numpy-2.2.5 scipy-1.15.2 xgboost-3.1.0
 
 #### What happened ?
 
-`XGBoost` is available as CUDA accelarated, PIP detects it, however it is not aware of any NVIDIA CUDA support 
-and reports it:
+`XGBoost` is available as CUDA accelarated, PIP detects it, however it is not
+aware of any NVIDIA CUDA support and reports it:
+
 ```bash
 Variant `aa00cb06` has been rejected because one or many of the variant properties `[nvidia :: driver :: 12]` are not supported or have been explicitly rejected.
 ```
 
-Similarly, `Numpy` is being optimized for different `x86_64` versions, PIP detects it, however it is not aware 
-of which `x86_64` version this machine is and reports it:
+Similarly, `Numpy` is being optimized for different `x86_64` versions, PIP
+detects it, however it is not aware of which `x86_64` version this machine is
+and reports it:
+
 ```bash
 Variant `3b930df5` has been rejected because one or many of the variant properties `[x86_64 :: level :: v1]` are not supported or have been explicitly rejected.
 Variant `40aba78e` has been rejected because one or many of the variant properties `[x86_64 :: level :: v2]` are not supported or have been explicitly rejected.
@@ -300,17 +305,20 @@ Variant `fa7c1393` has been rejected because one or many of the variant properti
 ```
 
 Consequently the "default wheel" - a `non-variant` is being picked up:
+
 ```bash
-numpy-2.2.5 
-scipy-1.15.2 
+numpy-2.2.5
+scipy-1.15.2
 xgboost-3.1.0
 ```
 
 #### 2.2 Installing the NVIDIA Variant Provider - PIP should install a CUDA-accelerated build
 
 > [!WARNING]
+>
 > - This part requires CUDA 11.8 or >=12.6 and an NVIDIA GPU to function.
-> - The behavior can be mocked using the environment variable: `NV_PROVIDER_FORCE_DRIVER_VERSION==major.minor`
+> - The behavior can be mocked using the environment variable:
+>   `NV_PROVIDER_FORCE_DRIVER_VERSION==major.minor`
 
 ```bash
 # This can be used to "pretend" the system has a specific driver.
@@ -374,6 +382,7 @@ nvidia :: driver :: 12
 ```
 
 Alright now let's try to re-run the command to install `xgboost`. We should get:
+
 - `xgboost` built for `CUDA 12`
 - `NVIDIA-NCCL` built for `CUDA 12`
 
@@ -405,19 +414,22 @@ Would install numpy-2.2.5 nvidia-nccl-2.26.2-aa00cb06 scipy-1.15.2 xgboost-3.1.0
 
 #### What happened ?
 
-PIP is aware of NVIDIA CUDA and is able to detect the driver version. As my system reports it (see `nvidia-smi` above).
-NVIDIA CUDA 12.8 is installed on the machine, which explains why the NVIDIA CUDA 11 build of `NVIDIA-NCCL` was rejected.
+PIP is aware of NVIDIA CUDA and is able to detect the driver version. As my
+system reports it (see `nvidia-smi` above). NVIDIA CUDA 12.8 is installed on the
+machine, which explains why the NVIDIA CUDA 11 build of `NVIDIA-NCCL` was
+rejected.
 
 ```bash
 Variant `73be618d` has been rejected because one or many of the variant properties `[nvidia :: driver :: 11]` are not supported or have been explicitly rejected.
 ```
 
 > [!IMPORTANT]  
-> Numpy is also `variant-enabled`. Please refer to the [`numpy` tutorial](./Numpy.md) to learn how to install `numpy` as a variant.
+> Numpy is also `variant-enabled`. Please refer to the
+> [`numpy` tutorial](./Numpy.md) to learn how to install `numpy` as a variant.
 
-> [!NOTE] 
-> **Exclusively on Linux** *[on Windows CUDA Libraries are statically linked]*
-> `nvidia-nccl` is only downloaded on Linux. 
+> [!NOTE] **Exclusively on Linux** \_[on Windows CUDA Libraries are statically >
+>
+> > linked]\_ > `nvidia-nccl` is only downloaded on Linux.
 
 The installed variant corresponds:
 
@@ -430,6 +442,8 @@ Variant-provider: nvidia: nvidia-variant-provider
 
 ### What's next ?
 
-We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` and see how it changes the output.
+We invite you to try playing with `NV_PROVIDER_FORCE_DRIVER_VERSION` and see how
+it changes the output.
+
 - Valid Values: `[CUDA 12] any version`
 - Any other values: installation of the normal `non-variant` Wheel (CPU only)

--- a/docs/tutorials/meson-python.md
+++ b/docs/tutorials/meson-python.md
@@ -2,28 +2,24 @@
 
 ## Purpose
 
-This document provides a quick guide how to utilize [the variant-capable
-fork of `meson-python`](
-https://github.com/wheelnext/meson-python/tree/wheel-variants) in order
-to build variant wheels. We also provide [a forked version of NumPy
-with sample variant configuration](
-https://github.com/wheelnext/numpy/tree/wheel-variants).
-
+This document provides a quick guide how to utilize
+[the variant-capable fork of `meson-python`](https://github.com/wheelnext/meson-python/tree/wheel-variants)
+in order to build variant wheels. We also provide
+[a forked version of NumPy with sample variant configuration](https://github.com/wheelnext/numpy/tree/wheel-variants).
 
 ## Determining the plugins to use
 
-Provider plugins determine the available variants. Currently,
-the wheelnext project provides the following plugins:
+Provider plugins determine the available variants. Currently, the wheelnext
+project provides the following plugins:
 
 | Package                                                                           | Use case                                | Example property             | `plugin-api`                                         |
-|-----------------------------------------------------------------------------------|-----------------------------------------|------------------------------|------------------------------------------------------|
+| --------------------------------------------------------------------------------- | --------------------------------------- | ---------------------------- | ---------------------------------------------------- |
 | [nvidia-variant-provider](https://github.com/wheelnext/nvidia-variant-provider)   | CUDA driver version                     | `nvidia :: cuda :: 12.8`     | `nvidia_variant_provider.plugin:NvidiaVariantPlugin` |
 | [provider-variant-aarch64](https://github.com/wheelnext/provider-variant-aarch64) | ARM architecture version, extensions    | `aarch64 :: version :: 8.3a` | `provider_variant_aarch64.plugin:AArch64Plugin`      |
 | [provider-variant-x86-64](https://github.com/wheelnext/provider-variant-x86-64)   | x86_64 architecture version, extensions | `x86_64 :: level :: 3`       | `provider_variant_x86_64.plugin:X8664Plugin`         |
 
 To determine the exact list of properties available, install the plugin,
 `variantlib` and use the `variantlib plugins` commands, e.g.:
-
 
 ### 1. Create a virtualenv to isolate your environment
 
@@ -42,7 +38,7 @@ Then let's install some plugins and query variantlib to probe the system
 ```bash
 $ python3 -m pip install "variantlib[cli]" provider-variant-aarch64 provider-variant-x86_64
 $ variantlib plugins get-all-configs
-variantlib plugins get-all-configs                                                       
+variantlib plugins get-all-configs
 variantlib.plugins.py_envs - INFO - Using externally managed python environment
 variantlib.plugins.loader - INFO - Plugin discovered via entry point: provider_variant_x86_64 = provider_variant_x86_64.plugin:X8664Plugin; provided by package provider-variant-x86-64 0.0.1.post1
 variantlib.plugins.loader - INFO - Loading plugin via provider_variant_x86_64.plugin:X8664Plugin
@@ -71,11 +67,11 @@ Installed plugins on the user machine are auto-detected using entry-points.
 
 ## Updating `pyproject.toml`
 
-To enable variant support within a project using `meson-python`,
-the following changes need to be made to its `pyproject.toml` file:
+To enable variant support within a project using `meson-python`, the following
+changes need to be made to its `pyproject.toml` file:
 
-1. The `build-system.requires` list must use the wheelnext fork
-   of `meson-python`. For example:
+1. The `build-system.requires` list must use the wheelnext fork of
+   `meson-python`. For example:
 
    ```toml
    [build-system]
@@ -85,9 +81,9 @@ the following changes need to be made to its `pyproject.toml` file:
    ]
    ```
 
-2. `[variant.providers.<variant_namespace>]` section need to be added, indicating how to
-   install the provider plugins, and how to import their provider
-   classes. For example:
+2. `[variant.providers.<variant_namespace>]` section need to be added,
+   indicating how to install the provider plugins, and how to import their
+   provider classes. For example:
 
    ```toml
    [variant.providers.aarch64]
@@ -99,30 +95,27 @@ the following changes need to be made to its `pyproject.toml` file:
    plugin-api = "provider_variant_x86_64.plugin:X8664Plugin"
    ```
 
-   The last component of the table name must correspond to the plugin's
-   variant namespace. The `requires` key indicates how to install
-   the plugin, whereas the `plugin-api` key needs to be the value
-   taken from the plugin table.
+   The last component of the table name must correspond to the plugin's variant
+   namespace. The `requires` key indicates how to install the plugin, whereas
+   the `plugin-api` key needs to be the value taken from the plugin table.
 
-3. Finally, a list of namespace priorities needs to be defined for
-   the plugins that will be installed by default. The list will
-   determine which variants will take precedence when installing.
-   For example:
+3. Finally, a list of namespace priorities needs to be defined for the plugins
+   that will be installed by default. The list will determine which variants
+   will take precedence when installing. For example:
 
    ```toml
    [variant.default-priorities]
    namespace = ["aarch64", "x86_64"]
    ```
 
-   Note that in this particular case the variants are mutually
-   exclusive, so the actual order does not matter.
-
+   Note that in this particular case the variants are mutually exclusive, so the
+   actual order does not matter.
 
 ## Building without explicit `meson.build` support
 
-At this point, it is already possible to start building variant wheels.
-For example, to build a wheel for `x86_64 :: level :: v3` baseline,
-the following command can be used:
+At this point, it is already possible to start building variant wheels. For
+example, to build a wheel for `x86_64 :: level :: v3` baseline, the following
+command can be used:
 
 ```console
 $ python3 -m pip install -q build
@@ -153,8 +146,8 @@ Host machine cpu: x86_64
 Program python found: YES (/tmp/build-env-l7iyan__/bin/python)
 Found pkg-config: YES (/usr/bin/pkg-config) 2.4.3
 Run-time dependency python found: YES 3.13
-Has header "Python.h" with dependency python-3.13: YES 
-Compiler for C supports arguments -fno-strict-aliasing: YES 
+Has header "Python.h" with dependency python-3.13: YES
+Compiler for C supports arguments -fno-strict-aliasing: YES
 Message: Appending option "detect" to "cpu-baseline" due to detecting global architecture c_arg "-march=x86-64-v3"
 [...]
 Message:
@@ -169,32 +162,29 @@ CPU Optimization Options
 Successfully built numpy-2.2.5-cp313-cp313-linux_x86_64-fa7c1393.whl
 ```
 
-The `-Cvariant-name=...` option specifies the variant property to build
-for. It can be used multiple times to combine multiple properties.
-In the case of `aarch64 :: version` and `x86_64 :: level` properties,
-this option also automatically adjusts compiler flags to build
-for the specified baseline. In case of other plugins and properties,
-a manual setup may be necessary to ensure that the specified variant
-is actually built — rather than just marked.
-
+The `-Cvariant-name=...` option specifies the variant property to build for. It
+can be used multiple times to combine multiple properties. In the case of
+`aarch64 :: version` and `x86_64 :: level` properties, this option also
+automatically adjusts compiler flags to build for the specified baseline. In
+case of other plugins and properties, a manual setup may be necessary to ensure
+that the specified variant is actually built — rather than just marked.
 
 ## Updating `meson.build` (optional)
 
-In addition to using the standard provider plugin functionality, it is
-also possible to explicitly pass built variant properties to the Meson
-build system. In order to facilitate this, the `variant` option needs
-to be added to `meson.options` (or `meson_options.txt`) file:
+In addition to using the standard provider plugin functionality, it is also
+possible to explicitly pass built variant properties to the Meson build system.
+In order to facilitate this, the `variant` option needs to be added to
+`meson.options` (or `meson_options.txt`) file:
 
 ```meson
 option('variant', type: 'array', value: [],
         description: 'Wheel variant keys')
 ```
 
-The option takes an array of variant properties
-in the `namespace :: feature :: value` form. For example, the following
-code can be used in `meson.build` to get the value
-of `x86_64 :: level` feature and put it into `x86_64_variant` varible,
-if used:
+The option takes an array of variant properties in the
+`namespace :: feature :: value` form. For example, the following code can be
+used in `meson.build` to get the value of `x86_64 :: level` feature and put it
+into `x86_64_variant` varible, if used:
 
 ```meson
 x86_64_variant = ''
@@ -216,8 +206,8 @@ endforeach
 ```
 
 To use this option, `-Cvariant=` option needs to be used instead of
-`-Cvariant-name=`. Variant properties specified via this option are
-additionally passed to `meson setup`:
+`-Cvariant-name=`. Variant properties specified via this option are additionally
+passed to `meson setup`:
 
 ```console
 $ python3 -m build -w -Cvariant=x86_64::level::v3
@@ -243,6 +233,5 @@ CPU Optimization Options
 Successfully built numpy-2.2.5-cp313-cp313-linux_x86_64-fa7c1393.whl
 ```
 
-Note that the `-Cvariant` property resulted in `-Dvariant` option
-being passed to `meson setup`, which in turn changed the CPU
-optimization options.
+Note that the `-Cvariant` property resulted in `-Dvariant` option being passed
+to `meson setup`, which in turn changed the CPU optimization options.


### PR DESCRIPTION
Manually wrapping the lines in markdown files is cumbersome, so I've added prettier which prose-wraps and formats those files for us. It also gives us consistency between the files that are currently not wrapped at a line length and those that are.

The only text change is the new "Contributing" section that explains how to run prettier:

```
npx prettier --prose-wrap always --write "**/*.md"
```